### PR TITLE
Support protolude version 0.3.0

### DIFF
--- a/src/ApplicativeNormalisation.hs
+++ b/src/ApplicativeNormalisation.hs
@@ -1,7 +1,7 @@
 {-# language OverloadedStrings #-}
 module ApplicativeNormalisation where
 
-import Protolude hiding (evaluate, Type)
+import Protolude hiding (evaluate, Type, typeOf)
 
 import qualified Applicative.Syntax as Applicative
 import qualified Builtin

--- a/src/ClosureConverted/TypeOf.hs
+++ b/src/ClosureConverted/TypeOf.hs
@@ -2,7 +2,7 @@
 {-# language RankNTypes #-}
 module ClosureConverted.TypeOf where
 
-import Protolude hiding (head)
+import Protolude hiding (head, typeOf)
 
 import Rock
 

--- a/src/TypeOf.hs
+++ b/src/TypeOf.hs
@@ -1,7 +1,7 @@
 {-# language OverloadedStrings #-}
 module TypeOf where
 
-import Protolude
+import Protolude hiding (typeOf)
 
 import Rock
 


### PR DESCRIPTION
Version 0.3.0 exports typeOf, which we then just hide since it conflicts with existing identifiers. This results in warnings though for people still using 0.2.4 since there is nothing to hide, even though it still works fine. Is there a better way to do this, or is this fine, or should only version 0.2.4 be supported?